### PR TITLE
Include the config dir when building installDist

### DIFF
--- a/gate-package/gate-package.gradle
+++ b/gate-package/gate-package.gradle
@@ -48,3 +48,13 @@ tasks.withType(org.springframework.boot.gradle.run.BootRunTask) {
 bootRepackage.enabled = false
 
 mainClassName = 'com.netflix.spinnaker.gate.Main'
+
+distributions {
+  main {
+    contents {
+      into ('config') {
+        from 'root/apps/gate/config'
+      }
+    }
+  }
+}


### PR DESCRIPTION
Hi Adam, thank you for this example of extending gate! It's been a huge help for some work we've been on recently.

One thing we noticed though was that the gate.yml was being used when running locally via bootRun, but wasn't there when running from a distribution build. Rather than move the files around in the repo or hack around it with some post-build scripts we just added the whole dir to the distribution. Figured it might help someone else if they're doing anything similar.